### PR TITLE
Adding TX mapping for ESP-WROOM-32

### DIFF
--- a/Supported Boards.md
+++ b/Supported Boards.md
@@ -43,6 +43,6 @@ Supported by the ESPHome Ratgdo port, using the ESP32 D1 Mini YAML file for inst
 ![ESP-WROOM-32 board](https://github.com/Kaldek/rat-ratgdo/blob/main/images/ESP-WROOM-32%20board.jpg)
 
 GPIO pins for the ESP-WROOM-32 are as follows:
-- TX: Find what maps to GPIO16
+- TX: RX2
 - RX: D21
 - Obstruction: D23


### PR DESCRIPTION
- Added TX pin mapping for ESP-WROOM-32 board
- Included a picture of my prototype board using a ESP-WROOM-32

![0](https://github.com/Kaldek/rat-ratgdo/assets/113391793/cbe4a4f0-f842-44de-a934-bde8b77d1901)
